### PR TITLE
Don't override existing package dependencies.

### DIFF
--- a/src/_common/package.js
+++ b/src/_common/package.js
@@ -69,7 +69,7 @@ module.exports = (packageConf) => {
   packageConf.dependencies = packageConf.dependencies || {};
   // debug is really nice, all my modules should use it,
   // it makes debugging so simple
-  packageConf.dependencies.debug = '2.6.1';
+  packageConf.dependencies.debug = packageConf.dependencies.debug || '2.6.1';
 
   // Add the MUST HAVE dev dependencies
   packageConf.devDependencies = packageConf.devDependencies || {};


### PR DESCRIPTION
I was trying to update dependencies in svg-pathdata, but this is resetting it. Updating dependencies needs to be done on per-package basis anyways as updates might break things, so I'm not sure setting dependencies globally makes sense...

The same could be done with the devdependencies but I'm not sure if there are scripts in metapak-nfroidure which depend on specific versions, so that could break them. Just toss the PR if this would break something.
